### PR TITLE
Fix for get_community function

### DIFF
--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -335,7 +335,7 @@ class LemmyHttp(object):
 
         form = create_form(locals())
         form["auth"] = self.key
-        return get_handler(f"{self._api_url}/community", self._headers, form)
+        return get_handler(f"{self._api_url}/community", self._headers, json=None, params=form)
 
     def get_modlog(self, type_: str, community_id: int = None,
                    limit: int = None, mod_person_id: int = None,

--- a/plemmy/utils.py
+++ b/plemmy/utils.py
@@ -28,11 +28,11 @@ def put_handler(url: str, headers: dict, json: dict) -> requests.Response:
     return re
 
 
-def get_handler(url: str, headers: dict, json: dict) -> requests.Response:
+def get_handler(url: str, headers: dict, json: dict, params: dict = None) -> requests.Response:
 
     logger = logging.getLogger(__name__)
     try:
-        re = requests.get(url, headers=headers, json=json)
+        re = requests.get(url, headers=headers, json=json, params=params)
         logger.debug(f"Code: {re.status_code}")
     except requests.exceptions.RequestException as ex:
         logger.error(f"GET error: {ex}\n\nURL: {url}" +


### PR DESCRIPTION
I'm not sure why, but lemmy doesn't seem to accept `name` or `id` in request body for that endpoint (returns HTTP code 400 - `{"error":"no_id_given"}`. When it is passed as a param, it works.

Example code to test:
```py
from plemmy import LemmyHttp

api = LemmyHttp("https://sh.itjust.works")
api.login("dummy_username", "dummy_password")
community = api.get_community(name="opensource@lemmy.ml")
print(community)
print(community.json())
```