### PR TITLE
add timeout function to requests

### DIFF
--- a/plemmy/utils.py
+++ b/plemmy/utils.py
@@ -16,7 +16,7 @@ def post_handler(url: str, headers: dict, json: dict) -> requests.Response:
 
     logger = logging.getLogger(__name__)
     try:
-        re = requests.post(url, headers=headers, json=json)
+        re = requests.post(url, headers=headers, json=json, timeout=30)
         logger.debug(f"Code: {re.status_code}")
     except requests.exceptions.RequestException as ex:
         logger.error(f"POST error: {ex}\n\nURL: {url}" +
@@ -39,7 +39,7 @@ def put_handler(url: str, headers: dict, json: dict) -> requests.Response:
 
     logger = logging.getLogger(__name__)
     try:
-        re = requests.put(url, headers=headers, json=json)
+        re = requests.put(url, headers=headers, json=json, timeout=30)
         logger.debug(f"Code: {re.status_code}")
     except requests.exceptions.RequestException as ex:
         logger.error(f"PUT error: {ex}\n\nURL: {url}" +
@@ -64,7 +64,7 @@ def get_handler(url: str, headers: dict, json: dict,
 
     logger = logging.getLogger(__name__)
     try:
-        re = requests.get(url, headers=headers, json=json, params=params)
+        re = requests.get(url, headers=headers, json=json, params=params, timeout=30)
         logger.debug(f"Code: {re.status_code}")
     except requests.exceptions.RequestException as ex:
         logger.error(f"GET error: {ex}\n\nURL: {url}" +


### PR DESCRIPTION
Creating a pull request to add timeout functionality to plemmy requests. On slow servers the requests can hang indefinitely requiring a stop and restart of the script. Set the timeout to 30 seconds. Tested against [https://lemmy.perthchat.org](https://lemmy.perthchat.org).