### PR TITLE
Added missing attribute in Community class

### DIFF
--- a/plemmy/objects.py
+++ b/plemmy/objects.py
@@ -130,6 +130,7 @@ class Community:
     posting_restricted_to_mods: bool = None
     instance_id: int = None
     updated: str = None
+    banner: bool = None
 
 
 @dataclass


### PR DESCRIPTION
With latest version of Lemmy running on some instance it's not possible anymore to instantiate Community from list_communities because of that missing attribute. 