### PR TITLE
Fixes

### DIFF
--- a/plemmy/responses.py
+++ b/plemmy/responses.py
@@ -318,7 +318,7 @@ class GetSiteResponse(object):
         response = api_response.json()
         self.admins = [PersonView(a) for a in response["admins"]]
         self.all_languages = [Language(**lang)
-                              for lang in response["discussion_languages"]]
+                              for lang in response["all_languages"]]
         if "my_user" in response.keys():
             self.my_user = response["my_user"]
         else:

--- a/plemmy/responses.py
+++ b/plemmy/responses.py
@@ -259,7 +259,6 @@ class GetPostResponse(object):
     def __init__(self, api_response: requests.Response) -> None:
 
         response = api_response.json()
-        print(response)
         self.community_view = CommunityView(response["community_view"])
         self.cross_posts = [PostView(p) for p in response["cross_posts"]]
         self.moderators = [CommunityModeratorView(m) for m in response["moderators"]]

--- a/plemmy/responses.py
+++ b/plemmy/responses.py
@@ -319,6 +319,7 @@ class GetSiteResponse(object):
         self.admins = [PersonView(a) for a in response["admins"]]
         self.all_languages = [Language(**lang)
                               for lang in response["all_languages"]]
+        self.discussion_languages = response["discussion_languages"]
         if "my_user" in response.keys():
             self.my_user = response["my_user"]
         else:

--- a/plemmy/responses.py
+++ b/plemmy/responses.py
@@ -259,9 +259,10 @@ class GetPostResponse(object):
     def __init__(self, api_response: requests.Response) -> None:
 
         response = api_response.json()
+        print(response)
         self.community_view = CommunityView(response["community_view"])
         self.cross_posts = [PostView(p) for p in response["cross_posts"]]
-        self.moderators = CommunityModeratorView(response["moderators"])
+        self.moderators = [CommunityModeratorView(m) for m in response["moderators"]]
         self.post_view = PostView(response["post_view"])
 
 


### PR DESCRIPTION
GetSiteResponse looks to prepare "all_languages" based on the "site" endpoint using the "Language" object. The language object is [code,id,name] which matches the published API, BUT GetSiteResponse is trying to use "discussion_languages" which is just a list of [id]s.

Attempting to enumerate anything from the site endpoint with GetSiteResponse illicits an error: 

`TypeError: plemmy.objects.Language() argument after ** must be a mapping, not int`

I believe this is a typo or perhaps human error in the lemmy api docs, or transposing from those docs. This PR changes "discussion_languages" to "all languages," and (if it's required) adds "discussion_languages" to return a list of language id's from "site" in the same way GetCommunityResponse does from "community."