### PR TITLE
bugfix for get_person_mentions(unread_only=...)

### DIFF
--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -985,7 +985,7 @@ class LemmyHttp(object):
         Returns:
             requests.Response: result of API call
         """
-
+        unread_only = str(unread_only).lower()
         form = create_form(locals())
         form["auth"] = self.key
         return get_handler(f"{self._api_url}/user/mention",

--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -985,7 +985,7 @@ class LemmyHttp(object):
         Returns:
             requests.Response: result of API call
         """
-        unread_only = str(unread_only).lower()
+
         form = create_form(locals())
         form["auth"] = self.key
         return get_handler(f"{self._api_url}/user/mention",

--- a/plemmy/utils.py
+++ b/plemmy/utils.py
@@ -84,6 +84,5 @@ def create_form(arguments: dict) -> dict:
     Returns:
         dict: constructed dictionary/form
     """
-
-    return {k: v for k, v in arguments.items()
+    return {k: str(v).lower() if isinstance(v, bool) else v for k, v in arguments.items()
             if v is not None and k != "self"}


### PR DESCRIPTION
When unread_only is given as a Python bool, fix error "Query deserialize error: provided string was not `true` or `false`"