### PR TITLE
Bug fixes

### DIFF
--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -988,6 +988,7 @@ class LemmyHttp(object):
 
         form = create_form(locals())
         form["auth"] = self.key
+        form["unread_only"] = str(unread_only).lower()
         return get_handler(f"{self._api_url}/user/mention",
                            self._headers, None, params=form)
 

--- a/plemmy/utils.py
+++ b/plemmy/utils.py
@@ -84,5 +84,5 @@ def create_form(arguments: dict) -> dict:
     Returns:
         dict: constructed dictionary/form
     """
-    return {k: str(v).lower() if isinstance(v, bool) else v for k, v in arguments.items()
+    return {k: v for k, v in arguments.items()
             if v is not None and k != "self"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ exclude = ["img*"]
 
 [project]
 name = "plemmy"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
     { name="Travis Kessler", email="travis.j.kessler@gmail.com" },
 ]


### PR DESCRIPTION
Per issue https://github.com/tjkessler/plemmy/issues/17, `block_community` did not work as of Plemmy version `0.3.4`. I've tracked down the cause: it looks like the changes made in PR https://github.com/tjkessler/plemmy/pull/15 to the `create_form` utility function, i.e., turning boolean variables into strings, only really applies to `get_person_mentions`, as other functions such as `block_community` actually _do_ require a boolean data type.

@mike-fmh: I had to revert some changes you made, but I think my solution of manually converting the boolean to a string fixes the `get_person_mentions` function. Not sure how many other similar functions are affected, feel free to make similar changes and make a PR if you run into any issues.

Very unfortunate that the API has some datatype mismatching, hopefully this will be fixed in the future.

Thanks to @AndrewFlan for pointing me in the right direction!

New version will be `0.3.5`.