### PR TITLE
Bugfix: Adds a missing string conversion in get_replies()

### DIFF
--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1062,6 +1062,7 @@ class LemmyHttp(object):
         """
 
         form = create_form(locals())
+        form["unread_only"] = str(unread_only).lower()
         return get_handler(self._session, f"{self._api_url}/user/replies",
                            None, params=form)
 


### PR DESCRIPTION
get_replies() are missing the conversion of _unread_only_ from bool to string, causing there to be a mismatch between the param type hint and what are valid input ("true"/"false"). Inputting a bool for _unread_only_ without this fix will return an error from the web request.