### PR TITLE
Add pagination support to get_posts

### DIFF
--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -3,7 +3,7 @@ import requests
 from typing import List
 from typing_extensions import Self
 
-from .utils import create_session, post_handler, put_handler, get_handler,\
+from .utils import create_session, post_handler, put_handler, get_handler, \
     create_form
 
 API_VERSION = "v3"
@@ -1003,7 +1003,8 @@ class LemmyHttp(object):
     def get_posts(self, community_id: int = None, community_name: str = None,
                   limit: int = None, page: int = None, saved_only: bool = None,
                   sort: str = None,
-                  type_: str = None) -> requests.Response:
+                  type_: str = None,
+                  page_cursor: str = None) -> requests.Response:
         """ get_posts: obtain posts from a community
 
         Args:
@@ -1018,6 +1019,7 @@ class LemmyHttp(object):
                 "TopYear" (optional)
             type_ (str): "All", "Local", "Subscribed", "ModeratorView"
                 (optional)
+            page_cursor (str): cursor for pagination (optional)
 
         Returns:
             requests.Response: result of API call

--- a/plemmy/responses.py
+++ b/plemmy/responses.py
@@ -1,15 +1,15 @@
 import requests
 
-from .views import AdminPurgeCommentView, AdminPurgeCommunityView,\
-    AdminPurgePersonView, AdminPurgePostView, CommentReplyView,\
-    CommentReportView, CommentView, CommunityView, CommunityModeratorView,\
-    CustomEmojiView, FederatedInstances, ModAddView, ModAddCommunityView,\
-    ModBanView, ModBanFromCommunityView, ModFeaturePostView,\
-    ModHideCommunityView, ModLockPostView, ModRemoveCommentView,\
-    ModRemovePostView, ModTransferCommunityView, PersonMentionView,\
-    PersonView, PostReportView, PostView, PrivateMessageReportView,\
+from .views import AdminPurgeCommentView, AdminPurgeCommunityView, \
+    AdminPurgePersonView, AdminPurgePostView, CommentReplyView, \
+    CommentReportView, CommentView, CommunityView, CommunityModeratorView, \
+    CustomEmojiView, FederatedInstances, ModAddView, ModAddCommunityView, \
+    ModBanView, ModBanFromCommunityView, ModFeaturePostView, \
+    ModHideCommunityView, ModLockPostView, ModRemoveCommentView, \
+    ModRemovePostView, ModTransferCommunityView, PersonMentionView, \
+    PersonView, PostReportView, PostView, PrivateMessageReportView, \
     PrivateMessageView, RegistrationApplicationView, SiteView
-from .objects import CaptchaResponse, ImageFile, Language, SiteMetadata,\
+from .objects import CaptchaResponse, ImageFile, Language, SiteMetadata, \
     Tagline
 
 
@@ -17,7 +17,6 @@ class AddAdminResponse(object):
     """https://join-lemmy.org/api/interfaces/AddAdminResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.admins = PersonView(response["admins"])
 
@@ -26,7 +25,6 @@ class AddModToCommunityResponse(object):
     """https://join-lemmy.org/api/interfaces/AddModToCommunityResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.moderators = CommunityModeratorView(response["moderators"])
 
@@ -35,7 +33,6 @@ class BanFromCommunityResponse(object):
     """https://join-lemmy.org/api/interfaces/BanFromCommunityResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.banned = response["banned"]
         self.person_view = PersonView(response["person_view"])
@@ -45,7 +42,6 @@ class BanPersonResponse(object):
     """https://join-lemmy.org/api/interfaces/BanPersonResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.banned = response["banned"]
         self.person_view = PersonView(response["person_view"])
@@ -55,7 +51,6 @@ class BannedPersonsResponse(object):
     """https://join-lemmy.org/api/interfaces/BannedPersonsResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.banned = [PersonView(p) for p in response["banned"]]
 
@@ -64,7 +59,6 @@ class BlockCommunityResponse(object):
     """https://join-lemmy.org/api/interfaces/BlockCommunityResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.blocked = response["blocked"]
         self.community_view = CommunityView(response["community_view"])
@@ -74,7 +68,6 @@ class BlockPersonResponse(object):
     """https://join-lemmy.org/api/interfaces/BlockPersonResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.blocked = response["blocked"]
         self.person_view = PersonView(response["person_view"])
@@ -84,7 +77,6 @@ class CommentReplyResponse(object):
     """https://join-lemmy.org/api/interfaces/CommentReplyResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.comment_reply_view = CommentReplyView(
             response["comment_reply_view"]
@@ -95,7 +87,6 @@ class CommentReportResponse(object):
     """https://join-lemmy.org/api/interfaces/CommentReportResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.comment_report_view = CommentReportView(
             response["comment_report_view"]
@@ -120,7 +111,6 @@ class CommunityResponse(object):
     """https://join-lemmy.org/api/interfaces/CommunityResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.community_view = CommunityView(response["community_view"])
         self.discussion_languages = response["discussion_languages"]
@@ -130,7 +120,6 @@ class CustomEmojiResponse(object):
     """https://join-lemmy.org/api/interfaces/CustomEmojiResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.custom_emoji = CustomEmojiView(response["custom_emoji"])
 
@@ -139,7 +128,6 @@ class DeleteCustomEmojiResponse(object):
     """https://join-lemmy.org/api/interfaces/DeleteCustomEmojiResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.id = response["id"]
         self.success = response["success"]
@@ -161,7 +149,6 @@ class GetCommentsResponse(object):
     """https://join-lemmy.org/api/interfaces/GetCommentsResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.comments = [CommentView(c) for c in response["comments"]]
 
@@ -170,7 +157,6 @@ class GetCommunityResponse(object):
     """https://join-lemmy.org/api/interfaces/GetCommunityResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.community_view = CommunityView(response["community_view"])
         self.discussion_languages = response["discussion_languages"]
@@ -196,7 +182,6 @@ class GetModlogResponse(object):
     """https://join-lemmy.org/api/interfaces/GetModlogResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.added = ModAddView(response["added"])
         self.added_to_community = ModAddCommunityView(
@@ -236,7 +221,6 @@ class GetPersonDetailsResponse(object):
     """https://join-lemmy.org/api/interfaces/GetPersonDetailsResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.comments = [CommentView(c) for c in response["comments"]]
         self.moderates = [CommunityModeratorView(m)
@@ -249,7 +233,6 @@ class GetPersonMentionsResponse(object):
     """https://join-lemmy.org/api/interfaces/GetPersonMentionsResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.mentions = PersonMentionView(response["mentions"])
 
@@ -258,7 +241,6 @@ class GetPostResponse(object):
     """https://join-lemmy.org/api/interfaces/GetPostResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.community_view = CommunityView(response["community_view"])
         self.cross_posts = [PostView(p) for p in response["cross_posts"]]
@@ -271,16 +253,15 @@ class GetPostsResponse(object):
     """https://join-lemmy.org/api/interfaces/GetPostsResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.posts = [PostView(p) for p in response["posts"]]
+        self.next_page = response["next_page"]
 
 
 class GetRepliesResponse(object):
     """https://join-lemmy.org/api/interfaces/GetRepliesResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.replies = CommentReplyView(response["replies"])
 
@@ -307,7 +288,6 @@ class GetSiteMetadataResponse(object):
     """https://join-lemmy.org/api/interfaces/GetSiteMetadataResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.metadata = SiteMetadata(**response["metadata"])
 
@@ -335,7 +315,6 @@ class GetUnreadCountResponse(object):
     """https://join-lemmy.org/api/interfaces/GetUnreadCountResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.mentions = response["mentions"]
         self.private_messages = response["private_messages"]
@@ -346,7 +325,6 @@ class GetUnreadRegistrationApplicationCountResponse(object):
     """https://join-lemmy.org/api/interfaces/GetUnreadRegistrationApplicationCountResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.registration_applications = response["registration_applications"]
 
@@ -355,7 +333,6 @@ class ListCommentReportsResponse(object):
     """https://join-lemmy.org/api/interfaces/ListCommentReportsResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.comment_reports = [CommentReportView(v)
                                 for v in response["comment_reports"]]
@@ -365,7 +342,6 @@ class ListCommunitiesResponse(object):
     """https://join-lemmy.org/api/interfaces/ListCommunitiesResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.communities = [CommunityView(c) for c in response["communities"]]
 
@@ -374,7 +350,6 @@ class ListPostReportsResponse(object):
     """https://join-lemmy.org/api/interfaces/ListPostReportsResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.post_reports = [PostReportView(r)
                              for r in response["post_reports"]]
@@ -384,7 +359,6 @@ class ListPrivateMessageReportsResponse(object):
     """https://join-lemmy.org/api/interfaces/ListPrivateMessageReportsResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.private_message_reports = [PrivateMessageReportView(r)
                                         for r in response[
@@ -396,7 +370,6 @@ class ListRegistrationApplicationsResponse(object):
     """https://join-lemmy.org/api/interfaces/ListRegistrationApplicationsResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.registration_applications = [RegistrationApplicationView(a)
                                           for a in response[
@@ -422,7 +395,6 @@ class PersonMentionResponse(object):
     """https://join-lemmy.org/api/interfaces/PersonMentionResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.person_mention_view = PersonMentionView(
             response["person_mention_view"]
@@ -433,7 +405,6 @@ class PostReportResponse(object):
     """https://join-lemmy.org/api/interfaces/PostReportResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.post_report_view = PostReportView(response["post_report_view"])
 
@@ -442,7 +413,6 @@ class PostResponse(object):
     """https://join-lemmy.org/api/interfaces/PostResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.post_view = PostView(response["post_view"])
 
@@ -451,7 +421,6 @@ class PrivateMessageReportResponse(object):
     """https://join-lemmy.org/api/interfaces/PrivateMessageReportResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.private_message_report_view = PrivateMessageReportView(
             response["private_message_report_view"]
@@ -462,7 +431,6 @@ class PrivateMessageResponse(object):
     """https://join-lemmy.org/api/interfaces/PrivateMessageResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.private_message_view = PrivateMessageView(
             response["private_message_view"]
@@ -473,7 +441,6 @@ class PurgeItemResponse(object):
     """https://join-lemmy.org/api/interfaces/PurgeItemResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.success = response["success"]
 
@@ -482,7 +449,6 @@ class RegistrationApplicationResponse(object):
     """https://join-lemmy.org/api/interfaces/RegistrationApplicationResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.registration_application = RegistrationApplicationView(
             response["registration_application"]
@@ -517,7 +483,6 @@ class SearchResponse(object):
     """https://join-lemmy.org/api/interfaces/SearchResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.comments = [CommentView(c) for c in response["comments"]]
         self.communities = [CommunityView(c) for c in response["communities"]]
@@ -530,7 +495,6 @@ class SiteResponse(object):
     """https://join-lemmy.org/api/interfaces/SiteResponse.html"""
 
     def __init__(self, api_response: requests.Response) -> None:
-
         response = api_response.json()
         self.site_view = SiteView(response["site_view"])
         self.taglines = [Tagline(**t) for t in response["taglines"]]

--- a/plemmy/utils.py
+++ b/plemmy/utils.py
@@ -70,14 +70,14 @@ def put_handler(session: requests.Session, url: str, json: dict,
     return re
 
 
-def get_handler(session: requests.Session, url: str, json: dict,
+def get_handler(session: requests.Session, url: str, json: dict | None = None,
                 params: dict = None) -> requests.Response:
     """ get_handler: handles all GET operations for Plemmy
 
     Args:
         session (requests.Session): open Lemmy session
         url (str): URL of API call
-        json (dict): json/form data
+        json (dict): json/form data (optional)
         params (dict, optional): parameters for GET operation
 
     Returns:


### PR DESCRIPTION
Introduced a 'page_cursor' parameter to the get_posts method for pagination. Enhanced get_handler to accept optional JSON data. Cleaned up imports and removed unnecessary blank lines in response classes.