### PR TITLE
Support new community aggregate field introduced in 0.19.5

### DIFF
--- a/plemmy/objects.py
+++ b/plemmy/objects.py
@@ -150,6 +150,7 @@ class CommunityAggregates:
     users_active_month: int = None
     users_active_half_year: int = None
     hot_rank: int = None
+    subscribers_local: int = None
 
 
 @dataclass

--- a/plemmy/objects.py
+++ b/plemmy/objects.py
@@ -150,7 +150,7 @@ class CommunityAggregates:
     users_active_month: int = None
     users_active_half_year: int = None
     hot_rank: int = None
-    subscribers_local: int = None
+    subscribers_local: Optional[int] = None
 
 
 @dataclass


### PR DESCRIPTION
Clients targeting servers running 0.19.5 are unable to load communities because they are missing the newly introduced field "subscribers_local" from CommunityAggregates. This add the field.