### PR TITLE
Be more lenient when unknown fields are returned by the API

### DIFF
--- a/plemmy/utils.py
+++ b/plemmy/utils.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 
 import requests
@@ -132,3 +133,13 @@ def create_form(arguments: dict) -> dict:
     """
     return {k: v for k, v in arguments.items()
             if v is not None and k != "self"}
+
+def call_with_filtered_kwargs(func, kwargs):
+    # Get the function's parameter names
+    func_args = inspect.signature(func).parameters
+
+    # Filter out kwargs that are not in the function's parameters
+    filtered_kwargs = {k: v for k, v in kwargs.items() if k in func_args}
+
+    # Call the function with the filtered kwargs
+    return func(**filtered_kwargs)

--- a/plemmy/views.py
+++ b/plemmy/views.py
@@ -7,6 +7,7 @@ from .objects import AdminPurgeComment, AdminPurgeCommunity, \
     ModRemovePost, ModTransferCommunity, Person, PersonAggregates, \
     PersonMention, Post, PostAggregates, PostReport, PrivateMessage, \
     PrivateMessageReport, RegistrationApplication, Site, SiteAggregates, ImageFile
+from .utils import call_with_filtered_kwargs
 
 
 class ViewObject(object):
@@ -26,13 +27,13 @@ class AdminPurgeCommentView(ViewObject):
     def parse(self) -> None:
 
         if "admin" in self._view.keys():
-            self.admin = Person(**self._view["admin"])
+            self.admin = call_with_filtered_kwargs(Person, self._view["admin"])
         else:
             self.admin = None
-        self.admin_purge_comment = AdminPurgeComment(
-            **self._view["admin_purge_comment"]
+        self.admin_purge_comment = call_with_filtered_kwargs(AdminPurgeComment,
+            self._view["admin_purge_comment"]
         )
-        self.post = Post(**self._view["post"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
 
 
 class AdminPurgeCommunityView(ViewObject):
@@ -41,7 +42,7 @@ class AdminPurgeCommunityView(ViewObject):
     def parse(self) -> None:
 
         if "admin" in self._view.keys():
-            self.admin = Person(**self._view["admin"])
+            self.admin = call_with_filtered_kwargs(Person, self._view["admin"])
         else:
             self.admin = None
         self.admin_purge_community = AdminPurgeCommunity(
@@ -55,7 +56,7 @@ class AdminPurgePersonView(ViewObject):
     def parse(self) -> None:
 
         if "admin" in self._view.keys():
-            self.admin = Person(**self._view["admin"])
+            self.admin = call_with_filtered_kwargs(Person, self._view["admin"])
         else:
             self.admin = None
         self.admin_purge_person = AdminPurgePerson(
@@ -68,11 +69,11 @@ class AdminPurgePostView(ViewObject):
 
     def parse(self) -> None:
         if "admin" in self._view.keys():
-            self.admin = Person(**self._view["admin"])
+            self.admin = call_with_filtered_kwargs(Person, self._view["admin"])
         self.admin_purge_post = AdminPurgePost(
             **self._view["admin_purge_post"]
         )
-        self.community = Community(**self._view["community"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
 
 
 class CommentReplyView(ViewObject):
@@ -80,11 +81,11 @@ class CommentReplyView(ViewObject):
 
     def parse(self) -> None:
 
-        self.comment = Comment(**self._view["comment"])
-        self.comment_reply = CommentReply(**self._view["comment_reply"])
-        self.community = Community(**self._view["community"])
-        self.counts = CommentAggregates(**self._view["counts"])
-        self.creator = Person(**self._view["creator"])
+        self.comment = call_with_filtered_kwargs(Comment, self._view["comment"])
+        self.comment_reply = call_with_filtered_kwargs(CommentReply, self._view["comment_reply"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.counts = call_with_filtered_kwargs(CommentAggregates, self._view["counts"])
+        self.creator = call_with_filtered_kwargs(Person, self._view["creator"])
         self.creator_banned_from_community = self._view[
             "creator_banned_from_community"
         ]
@@ -93,8 +94,8 @@ class CommentReplyView(ViewObject):
             self.my_vote = self._view["my_vote"]
         else:
             self.my_vote = None
-        self.post = Post(**self._view["post"])
-        self.recipient = Person(**self._view["recipient"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
+        self.recipient = call_with_filtered_kwargs(Person, self._view["recipient"])
         self.saved = self._view["saved"]
         self.subscribed = self._view["subscribed"]
 
@@ -104,12 +105,12 @@ class CommentReportView(ViewObject):
 
     def parse(self) -> None:
 
-        self.comment = Comment(**self._view["comment"])
-        self.comment_creator = Person(**self._view["comment_creator"])
-        self.comment_report = CommentReport(**self._view["comment_report"])
-        self.community = Community(**self._view["community"])
-        self.counts = CommentAggregates(**self._view["counts"])
-        self.creator = Person(**self._view["creator"])
+        self.comment = call_with_filtered_kwargs(Comment, self._view["comment"])
+        self.comment_creator = call_with_filtered_kwargs(Person, self._view["comment_creator"])
+        self.comment_report = call_with_filtered_kwargs(CommentReport, self._view["comment_report"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.counts = call_with_filtered_kwargs(CommentAggregates, self._view["counts"])
+        self.creator = call_with_filtered_kwargs(Person, self._view["creator"])
         self.creator_banned_from_community = self._view[
             "creator_banned_from_community"
         ]
@@ -117,9 +118,9 @@ class CommentReportView(ViewObject):
             self.my_vote = self._view["my_vote"]
         else:
             self.my_vote = None
-        self.post = Post(**self._view["post"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
         if "resolver" in self._view.keys():
-            self.resolver = Person(**self._view["resolver"])
+            self.resolver = call_with_filtered_kwargs(Person, self._view["resolver"])
         else:
             self.resolver = None
 
@@ -129,10 +130,10 @@ class CommentView(ViewObject):
 
     def parse(self) -> None:
 
-        self.comment = Comment(**self._view["comment"])
-        self.community = Community(**self._view["community"])
-        self.counts = CommentAggregates(**self._view["counts"])
-        self.creator = Person(**self._view["creator"])
+        self.comment = call_with_filtered_kwargs(Comment, self._view["comment"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.counts = call_with_filtered_kwargs(CommentAggregates, self._view["counts"])
+        self.creator = call_with_filtered_kwargs(Person, self._view["creator"])
         self.creator_banned_from_community = self._view[
             "creator_banned_from_community"
         ]
@@ -141,7 +142,7 @@ class CommentView(ViewObject):
             self.my_vote = self._view["my_vote"]
         else:
             self.my_vote = None
-        self.post = Post(**self._view["post"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
         self.saved = self._view["saved"]
         self.subscribed = self._view["subscribed"]
 
@@ -150,8 +151,8 @@ class CommunityModeratorView(ViewObject):
     """https://join-lemmy.org/api/interfaces/CommunityModeratorView.html"""
 
     def parse(self) -> None:
-        self.community = Community(**self._view["community"])
-        self.moderator = Person(**self._view["moderator"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
 
 
 class CommunityView(ViewObject):
@@ -159,8 +160,8 @@ class CommunityView(ViewObject):
 
     def parse(self) -> None:
         self.blocked = self._view["blocked"]
-        self.community = Community(**self._view["community"])
-        self.counts = CommunityAggregates(**self._view["counts"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.counts = call_with_filtered_kwargs(CommunityAggregates, self._view["counts"])
         self.subscribed = self._view["subscribed"]
 
 
@@ -168,17 +169,17 @@ class CustomEmojiView(ViewObject):
     """https://join-lemmy.org/api/interfaces/CustomEmojiView.html"""
 
     def parse(self) -> None:
-        self.custom_emoji = CustomEmoji(**self._view["custom_emoji"])
-        self.keywords = CustomEmojiKeyword(**self._view["keywords"])
+        self.custom_emoji = call_with_filtered_kwargs(CustomEmoji, self._view["custom_emoji"])
+        self.keywords = call_with_filtered_kwargs(CustomEmojiKeyword, self._view["keywords"])
 
 
 class FederatedInstances(ViewObject):
     """https://join-lemmy.org/api/interfaces/FederatedInstances.html"""
 
     def parse(self) -> None:
-        self.allowed = [Instance(**i) for i in self._view["allowed"]]
-        self.blocked = [Instance(**i) for i in self._view["blocked"]]
-        self.linked = [Instance(**i) for i in self._view["linked"]]
+        self.allowed = [call_with_filtered_kwargs(Instance, i) for i in self._view["allowed"]]
+        self.blocked = [call_with_filtered_kwargs(Instance, i) for i in self._view["blocked"]]
+        self.linked = [call_with_filtered_kwargs(Instance, i) for i in self._view["linked"]]
 
 
 class ModAddCommunityView(ViewObject):
@@ -186,13 +187,13 @@ class ModAddCommunityView(ViewObject):
 
     def parse(self) -> None:
 
-        self.community = Community(**self._view["community"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
         self.mod_add_community = ModAddCommunity(
             **self._view["mod_add_community"]
         )
-        self.modded_person = Person(**self._view["modded_person"])
+        self.modded_person = call_with_filtered_kwargs(Person, self._view["modded_person"])
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
 
@@ -202,10 +203,10 @@ class ModAddView(ViewObject):
 
     def parse(self) -> None:
 
-        self.mod_add = ModAdd(**self._view["mod_add"])
-        self.modded_person = Person(**self._view["modded_person"])
+        self.mod_add = call_with_filtered_kwargs(ModAdd, self._view["mod_add"])
+        self.modded_person = call_with_filtered_kwargs(Person, self._view["modded_person"])
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
 
@@ -215,13 +216,13 @@ class ModBanFromCommunityView(ViewObject):
 
     def parse(self) -> None:
 
-        self.banned_person = Person(**self._view["banned_person"])
-        self.community = Community(**self._view["community"])
+        self.banned_person = call_with_filtered_kwargs(Person, self._view["banned_person"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
         self.mod_ban_from_community = ModBanFromCommunity(
             **self._view["mod_ban_from_community"]
         )
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
 
@@ -231,10 +232,10 @@ class ModBanView(ViewObject):
 
     def parse(self) -> None:
 
-        self.banned_person = Person(**self._view["banned_person"])
-        self.mod_ban = ModBan(**self._view["mod_ban"])
+        self.banned_person = call_with_filtered_kwargs(Person, self._view["banned_person"])
+        self.mod_ban = call_with_filtered_kwargs(ModBan, self._view["mod_ban"])
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
 
@@ -244,15 +245,15 @@ class ModFeaturePostView(ViewObject):
 
     def parse(self) -> None:
 
-        self.community = Community(**self._view["community"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
         self.mod_feature_post = ModFeaturePost(
             **self._view["mod_feature_post"]
         )
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
-        self.post = Post(**self._view["post"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
 
 
 class ModHideCommunityView(ViewObject):
@@ -261,10 +262,10 @@ class ModHideCommunityView(ViewObject):
     def parse(self) -> None:
 
         if "admin" in self._view.keys():
-            self.admin = Person(**self._view["admin"])
+            self.admin = call_with_filtered_kwargs(Person, self._view["admin"])
         else:
             self.admin = None
-        self.community = Community(**self._view["community"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
         self.mod_hide_community = ModHideCommunity(
             **self._view["mod_hide_community"]
         )
@@ -275,13 +276,13 @@ class ModLockPostView(ViewObject):
 
     def parse(self) -> None:
 
-        self.community = Community(**self._view["community"])
-        self.mod_lock_post = ModLockPost(**self._view["mod_lock_post"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.mod_lock_post = call_with_filtered_kwargs(ModLockPost, self._view["mod_lock_post"])
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
-        self.post = Post(**self._view["post"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
 
 
 class ModRemoveCommentView(ViewObject):
@@ -289,17 +290,17 @@ class ModRemoveCommentView(ViewObject):
 
     def parse(self) -> None:
 
-        self.comment = Comment(**self._view["comment"])
-        self.commenter = Person(**self._view["commenter"])
-        self.community = Community(**self._view["community"])
+        self.comment = call_with_filtered_kwargs(Comment, self._view["comment"])
+        self.commenter = call_with_filtered_kwargs(Person, self._view["commenter"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
         self.mod_remove_comment = ModRemoveComment(
             **self._view["mod_remove_comment"]
         )
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
-        self.post = Post(**self._view["post"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
 
 
 class ModRemoveCommunityView(ViewObject):
@@ -307,12 +308,12 @@ class ModRemoveCommunityView(ViewObject):
 
     def parse(self) -> None:
 
-        self.community = Community(**self._view["community"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
         self.mod_remove_community = ModRemoveCommunity(
             **self._view["mod_remove_community"]
         )
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
 
@@ -322,13 +323,13 @@ class ModRemovePostView(ViewObject):
 
     def parse(self) -> None:
 
-        self.community = Community(**self._view["community"])
-        self.mod_remove_post = ModRemovePost(**self._view["mod_remove_post"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.mod_remove_post = call_with_filtered_kwargs(ModRemovePost, self._view["mod_remove_post"])
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
-        self.post = Post(**self._view["post"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
 
 
 class ModTransferCommunityView(ViewObject):
@@ -336,13 +337,13 @@ class ModTransferCommunityView(ViewObject):
 
     def parse(self) -> None:
 
-        self.community = Community(**self._view["community"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
         self.mod_transfer_community = ModTransferCommunity(
             **self._view["mod_transfer_community"]
         )
-        self.modded_person = Person(**self._view["modded_person"])
+        self.modded_person = call_with_filtered_kwargs(Person, self._view["modded_person"])
         if "moderator" in self._view.keys():
-            self.moderator = Person(**self._view["moderator"])
+            self.moderator = call_with_filtered_kwargs(Person, self._view["moderator"])
         else:
             self.moderator = None
 
@@ -352,10 +353,10 @@ class PersonMentionView(ViewObject):
 
     def parse(self) -> None:
 
-        self.comment = Comment(**self._view["comment"])
-        self.community = Community(**self._view["community"])
-        self.counts = CommentAggregates(**self._view["counts"])
-        self.creator = Person(**self._view["creator"])
+        self.comment = call_with_filtered_kwargs(Comment, self._view["comment"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.counts = call_with_filtered_kwargs(CommentAggregates, self._view["counts"])
+        self.creator = call_with_filtered_kwargs(Person, self._view["creator"])
         self.creator_banned_from_community = self._view[
             "creator_banned_from_community"
         ]
@@ -364,9 +365,9 @@ class PersonMentionView(ViewObject):
             self.my_vote = self._view["my_vote"]
         else:
             self.my_vote = None
-        self.person_mention = PersonMention(**self._view["person_mention"])
-        self.post = Post(**self._view["post"])
-        self.recipient = Person(**self._view["recipient"])
+        self.person_mention = call_with_filtered_kwargs(PersonMention, self._view["person_mention"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
+        self.recipient = call_with_filtered_kwargs(Person, self._view["recipient"])
         self.saved = self._view["saved"]
         self.subscribed = self._view["subscribed"]
 
@@ -375,8 +376,8 @@ class PersonView(ViewObject):
     """https://join-lemmy.org/api/interfaces/PersonView.html"""
 
     def parse(self) -> None:
-        self.counts = PersonAggregates(**self._view["counts"])
-        self.person = Person(**self._view["person"])
+        self.counts = call_with_filtered_kwargs(PersonAggregates, self._view["counts"])
+        self.person = call_with_filtered_kwargs(Person, self._view["person"])
 
 
 class PostReportView(ViewObject):
@@ -384,9 +385,9 @@ class PostReportView(ViewObject):
 
     def parse(self) -> None:
 
-        self.community = Community(**self._view["community"])
-        self.counts = PostAggregates(**self._view["counts"])
-        self.creator = Person(**self._view["creator"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.counts = call_with_filtered_kwargs(PostAggregates, self._view["counts"])
+        self.creator = call_with_filtered_kwargs(Person, self._view["creator"])
         self.creator_banned_from_community = self._view[
             "creator_banned_from_community"
         ]
@@ -394,11 +395,11 @@ class PostReportView(ViewObject):
             self.my_vote = self._view["my_vote"]
         else:
             self.my_vote = None
-        self.post = Post(**self._view["post"])
-        self.post_creator = Person(**self._view["post_creator"])
-        self.post_report = PostReport(**self._view["post_report"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
+        self.post_creator = call_with_filtered_kwargs(Person, self._view["post_creator"])
+        self.post_report = call_with_filtered_kwargs(PostReport, self._view["post_report"])
         if "resolver" in self._view.keys():
-            self.resolver = Person(**self._view["resolver"])
+            self.resolver = call_with_filtered_kwargs(Person, self._view["resolver"])
         else:
             self.resolver = None
 
@@ -408,9 +409,9 @@ class PostView(ViewObject):
 
     def parse(self) -> None:
 
-        self.community = Community(**self._view["community"])
-        self.counts = PostAggregates(**self._view["counts"])
-        self.creator = Person(**self._view["creator"])
+        self.community = call_with_filtered_kwargs(Community, self._view["community"])
+        self.counts = call_with_filtered_kwargs(PostAggregates, self._view["counts"])
+        self.creator = call_with_filtered_kwargs(Person, self._view["creator"])
         self.creator_banned_from_community = self._view[
             "creator_banned_from_community"
         ]
@@ -419,7 +420,7 @@ class PostView(ViewObject):
             self.my_vote = self._view["my_vote"]
         else:
             self.my_vote = None
-        self.post = Post(**self._view["post"])
+        self.post = call_with_filtered_kwargs(Post, self._view["post"])
         self.read = self._view["read"]
         self.saved = self._view["saved"]
         self.subscribed = self._view["subscribed"]
@@ -431,8 +432,8 @@ class PrivateMessageReportView(ViewObject):
 
     def parse(self) -> None:
 
-        self.creator = Person(**self._view["creator"])
-        self.private_message = PrivateMessage(**self._view["private_message"])
+        self.creator = call_with_filtered_kwargs(Person, self._view["creator"])
+        self.private_message = call_with_filtered_kwargs(PrivateMessage, self._view["private_message"])
         self.private_message_creator = Person(
             **self._view["private_message_creator"]
         )
@@ -440,7 +441,7 @@ class PrivateMessageReportView(ViewObject):
             **self._view["private_message_report"]
         )
         if "resolver" in self._view.keys():
-            self.resolver = Person(**self._view["resolver"])
+            self.resolver = call_with_filtered_kwargs(Person, self._view["resolver"])
         else:
             self.resolver = None
 
@@ -449,9 +450,9 @@ class PrivateMessageView(ViewObject):
     """https://join-lemmy.org/api/interfaces/PrivateMessageView.html"""
 
     def parse(self) -> None:
-        self.creator = Person(**self._view["creator"])
-        self.private_message = PrivateMessage(**self._view["private_message"])
-        self.recipient = Person(**self._view["recipient"])
+        self.creator = call_with_filtered_kwargs(Person, self._view["creator"])
+        self.private_message = call_with_filtered_kwargs(PrivateMessage, self._view["private_message"])
+        self.recipient = call_with_filtered_kwargs(Person, self._view["recipient"])
 
 
 class RegistrationApplicationView(ViewObject):
@@ -460,11 +461,11 @@ class RegistrationApplicationView(ViewObject):
     def parse(self) -> None:
 
         if "admin" in self._view.keys():
-            self.admin = Person(**self._view["admin"])
+            self.admin = call_with_filtered_kwargs(Person, self._view["admin"])
         else:
             self.admin = None
-        self.creator = Person(**self._view["creator"])
-        self.creator_local_user = LocalUser(**self._view["creator_local_user"])
+        self.creator = call_with_filtered_kwargs(Person, self._view["creator"])
+        self.creator_local_user = call_with_filtered_kwargs(LocalUser, self._view["creator_local_user"])
         self.registration_application = RegistrationApplication(
             **self._view["registration_application"]
         )
@@ -474,9 +475,9 @@ class SiteView(ViewObject):
     """https://join-lemmy.org/api/interfaces/SiteView.html"""
 
     def parse(self) -> None:
-        self.counts = SiteAggregates(**self._view["counts"])
-        self.local_site = LocalSite(**self._view["local_site"])
+        self.counts = call_with_filtered_kwargs(SiteAggregates, self._view["counts"])
+        self.local_site = call_with_filtered_kwargs(LocalSite, self._view["local_site"])
         self.local_site_rate_limit = LocalSiteRateLimit(
             **self._view["local_site_rate_limit"]
         )
-        self.site = Site(**self._view["site"])
+        self.site = call_with_filtered_kwargs(Site, self._view["site"])


### PR DESCRIPTION
Replaces dictionary unpacking calls with a wrapper that first filters out any unknown fields. This should prevent issues like #39 and #42, where the developer add new fields to existing responses without versioning the API.