### PR TITLE
Remove the raising of Exception on login failure.

### DIFF
--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1311,13 +1311,14 @@ class LemmyHttp(object):
         return post_handler(self._session, f"{self._api_url}/post/lock", form)
 
     def login(self, username_or_email: str,
-              password: str) -> requests.Response:
+              password: str, totp_2fa_token: str = None) -> requests.Response:
         """ login: login to Lemmy instance, setting `LemmyHttp._session` jwt to
         authenticated user jwt
 
         Args:
             username_or_email (str): username or email for login
             password (str): password for login
+            totp_2fa_token (str): 2FA token if enabled
 
         Returns:
             requests.Response: result of API call

--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1146,6 +1146,20 @@ class LemmyHttp(object):
             None, None
         )
 
+    def hide_community(self, community_id: int, hidden: bool, reason: str = '') -> requests.Response:
+        """ hide_community: Hide a community from public / "All" view. Admins only.
+
+        Args:
+            community_id (int): ID of community to hide
+            hidden (bool): True if hidden, False otherwise
+            reason (str): reason for hiding community
+
+        Returns:
+            requests.Response: result of API call
+        """
+        form = create_form(locals())
+        return put_handler(self._session, f"{self._api_url}/community/hide", form)
+
     def leave_admin(self) -> requests.Response:
         """ leave_admin: current user leaves admin group
 

--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1327,8 +1327,6 @@ class LemmyHttp(object):
         re = post_handler(self._session, f"{self._api_url}/user/login", form)
         if re.status_code == 200:
             self._session = create_session(self._headers, re.json()["jwt"])
-        else:
-            raise Exception("Login failed with status code: " + str(re.status_code))
         return re
 
     def mark_all_as_read(self) -> requests.Response:


### PR DESCRIPTION
As suggested in #46, this pull request makes it so developers get more granular control over how to treat login failure by passing the response object even if status code isn't 200.

This change may however cause problems for any people that relies on `try: ___ except Exception:` when logging in to a session if the session login fails.