### PR TITLE
Fixes uncaught AttributeError in login()

### DIFF
--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1311,13 +1311,14 @@ class LemmyHttp(object):
         return post_handler(self._session, f"{self._api_url}/post/lock", form)
 
     def login(self, username_or_email: str,
-              password: str) -> requests.Response:
+              password: str, totp_2fa_token: str = None) -> requests.Response:
         """ login: login to Lemmy instance, setting `LemmyHttp._session` jwt to
         authenticated user jwt
 
         Args:
             username_or_email (str): username or email for login
             password (str): password for login
+            totp_2fa_token (str): 2FA token if enabled
 
         Returns:
             requests.Response: result of API call

--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1319,16 +1319,19 @@ class LemmyHttp(object):
             username_or_email (str): username or email for login
             password (str): password for login
 
+        Raises:
+            requests.ConnectionError: if no connection to server could be made
+
         Returns:
             requests.Response: result of API call
         """
 
         form = create_form(locals())
         re = post_handler(self._session, f"{self._api_url}/user/login", form)
+        if not isinstance(re, requests.Response):
+            raise requests.ConnectionError("Login failed as no connection to server could be made.")
         if re.status_code == 200:
             self._session = create_session(self._headers, re.json()["jwt"])
-        else:
-            raise Exception("Login failed with status code: " + str(re.status_code))
         return re
 
     def mark_all_as_read(self) -> requests.Response:

--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1146,6 +1146,21 @@ class LemmyHttp(object):
             None, None
         )
 
+    def hide_community(self, community_id: int, hidden: bool, reason: str = '') -> requests.Response:
+        """ hide_community: Hide a community from public / "All" view. Admins only.
+
+        Args:
+            community_id (int): ID of community to hide
+            hidden (bool): True if hidden, False otherwise
+            reason (str): reason for hiding community
+
+        Returns:
+            requests.Response: result of API call
+        """
+        form = create_form(locals())
+        return put_handler(self._session, f"{self._api_url}/community/hide",
+                            form)
+
     def leave_admin(self) -> requests.Response:
         """ leave_admin: current user leaves admin group
 

--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1157,6 +1157,7 @@ class LemmyHttp(object):
         Returns:
             requests.Response: result of API call
         """
+
         form = create_form(locals())
         return put_handler(self._session, f"{self._api_url}/community/hide",
                             form)

--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1319,16 +1319,22 @@ class LemmyHttp(object):
             username_or_email (str): username or email for login
             password (str): password for login
 
+        Raises:
+            requests.ConnectionError: if no connection to server could be made
+            requests.HTTPError: if login fails with status code other than 200
+
         Returns:
             requests.Response: result of API call
         """
 
         form = create_form(locals())
         re = post_handler(self._session, f"{self._api_url}/user/login", form)
-        if re.status_code == 200:
+        if not isinstance(re, requests.Response):
+            raise requests.ConnectionError("Login failed as no connection to server could be made.")
+        elif re.status_code == 200:
             self._session = create_session(self._headers, re.json()["jwt"])
         else:
-            raise Exception("Login failed with status code: " + str(re.status_code))
+            raise requests.HTTPError("Login failed with status code: " + str(re.status_code))
         return re
 
     def mark_all_as_read(self) -> requests.Response:


### PR DESCRIPTION
Currently login() will cause an AttributeError if login is attempted without internet connection as post_handler will return None, meaning the check `re.status_code == 200` cannot be done. This PR checks the type of `re` and raises `requests.ConnectionError` if the request to the server couldn't be made.

It also changes the status code exception raised for `re.status_code != 200` from `Exception` to the more precise exception `requests.HTTPError`.