### PR TITLE
Remove the raising of Exception on status code != 200

### DIFF
--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1319,16 +1319,19 @@ class LemmyHttp(object):
             username_or_email (str): username or email for login
             password (str): password for login
 
+        Raises:
+            requests.ConnectionError: if no connection to server could be made
+
         Returns:
             requests.Response: result of API call
         """
 
         form = create_form(locals())
         re = post_handler(self._session, f"{self._api_url}/user/login", form)
+        if not isinstance(re, requests.Response):
+            raise requests.ConnectionError("Login failed as no connection to server could be made.")
         if re.status_code == 200:
             self._session = create_session(self._headers, re.json()["jwt"])
-        else:
-            raise Exception("Login failed with status code: " + str(re.status_code))
         return re
 
     def mark_all_as_read(self) -> requests.Response:


### PR DESCRIPTION
Currently login() will raise `Exception` if login was unsuccessful/does not return status code 200. However it can be useful to have easy access to the status code to check *why* the login was unsuccessfully. With the current implementation you would need to scrape the status code by parsing the Exception message, which is different from how it's done for every other API call in lemmyhttp.py.