### PR TITLE
Adds the API call to hide communities

### DIFF
--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1146,6 +1146,21 @@ class LemmyHttp(object):
             None, None
         )
 
+    def hide_community(self, community_id: int, hidden: bool, reason: str = '') -> requests.Response:
+        """ hide_community: Hide a community from public / "All" view. Admins only.
+
+        Args:
+            community_id (int): ID of community to hide
+            hidden (bool): True if hidden, False otherwise
+            reason (str): reason for hiding community
+
+        Returns:
+            requests.Response: result of API call
+        """
+        form = create_form(locals())
+        return put_handler(self._session, f"{self._api_url}/community/hide",
+                            form)
+
     def leave_admin(self) -> requests.Response:
         """ leave_admin: current user leaves admin group
 

--- a/plemmy/lemmyhttp.py
+++ b/plemmy/lemmyhttp.py
@@ -1157,6 +1157,7 @@ class LemmyHttp(object):
         Returns:
             requests.Response: result of API call
         """
+
         form = create_form(locals())
         return put_handler(self._session, f"{self._api_url}/community/hide",
                             form)


### PR DESCRIPTION
As the title says, adds a function so that you can hide communities on an instance via an admin account.